### PR TITLE
add `llvm-tools-preview` component to install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ## Install
 
+add `llvm-tools-preview` rust component.
+
+```shell
+rustup component add llvm-tools-preview
+```
+
 get the file.
 
 ```shell


### PR DESCRIPTION
Error found with fresh rust 1.60 install.

```console
01:49:06 [ERROR] Error while executing llvm tools: We couldn't find llvm-profdata. Try installing the llvm-tools component with `rustup component add llvm-tools-preview`.
```